### PR TITLE
Remove incorrect statement about std::fmt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 
 This is a library for padding strings at runtime.
 
-The routines in `std::fmt` only work with formatting strings provided at
-compile-time, making them unsuitable for padding to a custom or
-user-defined value. Rather than re-implement all of `std::fmt`, padding is
-probably the most common use case, which is written in a more
-runtime-friendly fashion here.
-
 It provides four helper functions for the most common use cases, and one
 main function to cover the other cases.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,6 @@
 
 //! This is a library for padding strings at runtime.
 //!
-//! The routines in `std::fmt` only work with formatting strings provided at
-//! compile-time, making them unsuitable for padding to a custom or
-//! user-defined value. Rather than re-implement all of `std::fmt`, padding is
-//! probably the most common use case, which is written in a more
-//! runtime-friendly fashion here.
-//!
 //! It provides four helper functions for the most common use cases, and one
 //! main function (`pad`) to cover the other cases.
 //!


### PR DESCRIPTION
The docs claimed that std::fmt could not pad to widths defined at
run-time, but it can:

```
fn pad_at_runtime<T: Display>(t: T, n: usize) -> String {
    format!("{:width$}", t, width=n)
}
```