### PR TITLE
Unicode truncate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/pad/"
 homepage = "https://github.com/ogham/rust-pad"
 license = "MIT"
 readme = "README.md"
-version = "0.1.6"
+version = "0.2.0"
 
 [dependencies]
-unicode-width = "0.1.6"
+unicode-width = "0.1.9"

--- a/README.md
+++ b/README.md
@@ -100,10 +100,17 @@ in its entirety.
 You can instead tell it to pad with a maximum value, which will truncate
 the input when a string longer than the width is passed in.
 
+Unicode width is taken into account for this truncation. Since some unicode
+characters are more than 1 character width, it's possible for the truncated
+string to be smaller than the exact width, but the difference will be padded
+as usual.
+
 ```rust
 use pad::PadStr;
 let short = "short".with_exact_width(10);  // "short     "
 let long = "this string is long".with_exact_width(10);  // "this strin"
+let unicode_long = "大きい".with_exact_width(2);  // "大"
+let unicode_split = "大きい".with_exact_width(3);  // "大 "
 ```
 
 


### PR DESCRIPTION
Love this crate. Small, easy to find when its what you're looking for, well documented (with examples!) and does its job well. Thank you for creating this!

Had a small issue with truncating logic though, "with_exact_width" doesn't work with multi-space unicode characters, which is strange for a package using unicode_width for padding. This package was so small and well written, I decided to fix it myself, and I believe this is actually my first code pull request on github (outside of school).

Let me know any problems you have. `cargo fmt` applied formatting to some things outside of my changes. I also bumped the minor version so that other people using this dependency aren't broken in the case that they already have logic to compensate for how truncating unicode works in this package.


